### PR TITLE
Load sass is deprecated

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,6 @@ const commonConfig = merge([
       }),
     ],
   },
-  // parts.loadSASS(),
   parts.loadFonts({
     options: {
       name: '[name].[hash:8].[ext]',

--- a/webpack.parts.js
+++ b/webpack.parts.js
@@ -56,22 +56,6 @@ exports.loadCSS = ({ include, exclude } = {}) => ({
   },
 });
 
-// SASS is an awesome and powerful CSS preprocessor
-exports.loadSASS = ({ include, exclude } = {}) => ({
-  module: {
-    rules: [{
-      test: /\.scss$/,
-      include,
-      exclude,
-      use: [
-        'style-loader',
-        'css-loader',
-        'sass-loader',
-      ],
-    }],
-  },
-});
-
 // separating CSS from JS for faster loading
 exports.extractCSS = ({ include, exclude, use }) => {
   // Output extracted CSS to a file

--- a/webpack.parts.js
+++ b/webpack.parts.js
@@ -67,7 +67,7 @@ exports.extractCSS = ({ include, exclude, use }) => {
     module: {
       rules: [
         {
-          test: /\.css$/,
+          test: /\.(scss|css)$/,
           include,
           exclude,
 


### PR DESCRIPTION
Basically what happened was that I tried to enable CSS modules with SASS and apparently you can't do that.

Seriously just one option :/

And the CSS modules comes in a loader after SASS so I expected it to be fine.

Oh well.